### PR TITLE
feat: 3D world environment improvements

### DIFF
--- a/components/world/Character.tsx
+++ b/components/world/Character.tsx
@@ -6,9 +6,11 @@ import { useGLTF, useAnimations } from '@react-three/drei'
 import * as THREE from 'three'
 import type { Group } from 'three'
 import { usePlayerControls } from './usePlayerControls'
+import { FENCE_HALF } from './Fence'
 
 const WALK_SPEED = 4
 const ROTATION_SPEED = 10
+const BOUNDARY = FENCE_HALF - 0.4
 
 interface CharacterProps {
   characterRef: React.RefObject<Group | null>
@@ -70,6 +72,8 @@ export default function Character({ characterRef, walkTarget }: CharacterProps) 
       char.quaternion.slerp(_targetQuat, ROTATION_SPEED * delta)
 
       char.position.addScaledVector(_direction, WALK_SPEED * delta)
+      char.position.x = Math.max(-BOUNDARY, Math.min(BOUNDARY, char.position.x))
+      char.position.z = Math.max(-BOUNDARY, Math.min(BOUNDARY, char.position.z))
     }
 
     // Crossfade animations

--- a/components/world/Clouds.tsx
+++ b/components/world/Clouds.tsx
@@ -1,0 +1,56 @@
+import { useRef, useMemo } from 'react'
+import { useFrame } from '@react-three/fiber'
+import * as THREE from 'three'
+import type { Group } from 'three'
+
+const CLOUD_DEFS = [
+  { start: [-18, 11, -12], speed: 0.9, scale: 1.2 },
+  { start: [6, 13, -18], speed: 0.6, scale: 1.0 },
+  { start: [-4, 10, 8], speed: 1.1, scale: 0.85 },
+  { start: [22, 12, -6], speed: 0.7, scale: 1.3 },
+  { start: [-24, 11, -20], speed: 0.8, scale: 1.0 },
+  { start: [12, 14, 14], speed: 1.0, scale: 0.9 },
+]
+
+const BLOB_OFFSETS: [number, number, number][] = [
+  [0, 0, 0],
+  [0.9, 0.15, 0],
+  [-0.8, 0.1, 0],
+  [0.4, 0.35, 0.3],
+  [-0.3, 0.3, -0.3],
+  [0.5, -0.1, 0.4],
+]
+
+function Cloud({ start, speed, scale }: (typeof CLOUD_DEFS)[0]) {
+  const groupRef = useRef<Group>(null)
+  const startX = start[0]
+
+  useFrame((_, delta) => {
+    if (!groupRef.current) return
+    groupRef.current.position.x += delta * speed
+    if (groupRef.current.position.x > 32) {
+      groupRef.current.position.x = -32
+    }
+  })
+
+  return (
+    <group ref={groupRef} position={start as [number, number, number]} scale={scale}>
+      {BLOB_OFFSETS.map((offset, i) => (
+        <mesh key={i} position={offset}>
+          <sphereGeometry args={[0.8 - i * 0.04, 7, 5]} />
+          <meshToonMaterial color="#f0f4f8" />
+        </mesh>
+      ))}
+    </group>
+  )
+}
+
+export default function Clouds() {
+  return (
+    <>
+      {CLOUD_DEFS.map((def, i) => (
+        <Cloud key={i} {...def} />
+      ))}
+    </>
+  )
+}

--- a/components/world/Fence.tsx
+++ b/components/world/Fence.tsx
@@ -1,0 +1,95 @@
+import * as THREE from 'three'
+
+const gradientMap = (() => {
+  const map = new THREE.DataTexture(new Uint8Array([70, 160]), 2, 1)
+  map.needsUpdate = true
+  return map
+})()
+
+const POST_COLOR = '#8b6340'
+const RAIL_COLOR = '#a07848'
+export const FENCE_HALF = 10
+
+const POST_SPACING = 2
+const POST_HEIGHT = 1.1
+const RAIL_LOW = 0.38
+const RAIL_HIGH = 0.74
+const RAIL_THICKNESS = 0.07
+
+type Segment = {
+  postPositions: [number, number, number][]
+  railPositions: [number, number, number][]
+  railRotY: number
+  railLength: number
+}
+
+function buildSide(
+  axis: 'x' | 'z',
+  fixedVal: number,
+  from: number,
+  to: number
+): Segment {
+  const postPositions: [number, number, number][] = []
+  const railPositions: [number, number, number][] = []
+  const count = Math.round((to - from) / POST_SPACING)
+  for (let i = 0; i <= count; i++) {
+    const t = from + i * POST_SPACING
+    postPositions.push(
+      axis === 'x' ? [t, 0, fixedVal] : [fixedVal, 0, t]
+    )
+  }
+  for (let i = 0; i < count; i++) {
+    const mid = from + (i + 0.5) * POST_SPACING
+    railPositions.push(
+      axis === 'x' ? [mid, 0, fixedVal] : [fixedVal, 0, mid]
+    )
+  }
+  return {
+    postPositions,
+    railPositions,
+    railRotY: axis === 'z' ? Math.PI / 2 : 0,
+    railLength: POST_SPACING,
+  }
+}
+
+const SIDES: Segment[] = [
+  buildSide('x', -FENCE_HALF, -FENCE_HALF, FENCE_HALF),
+  buildSide('x',  FENCE_HALF, -FENCE_HALF, FENCE_HALF),
+  buildSide('z', -FENCE_HALF, -FENCE_HALF, FENCE_HALF),
+  buildSide('z',  FENCE_HALF, -FENCE_HALF, FENCE_HALF),
+]
+
+export default function Fence() {
+  return (
+    <>
+      {SIDES.flatMap((side, si) => [
+        ...side.postPositions.map((pos, pi) => (
+          <mesh key={`p-${si}-${pi}`} position={[pos[0], POST_HEIGHT / 2, pos[2]]} castShadow receiveShadow>
+            <cylinderGeometry args={[0.07, 0.09, POST_HEIGHT, 4]} />
+            <meshToonMaterial color={POST_COLOR} gradientMap={gradientMap} />
+          </mesh>
+        )),
+        ...side.railPositions.flatMap((pos, ri) => [
+          <mesh
+            key={`rl-${si}-${ri}`}
+            position={[pos[0], RAIL_LOW, pos[2]]}
+            rotation={[0, side.railRotY, 0]}
+            castShadow
+          >
+            <boxGeometry args={[side.railLength, RAIL_THICKNESS, RAIL_THICKNESS]} />
+            <meshToonMaterial color={RAIL_COLOR} gradientMap={gradientMap} />
+          </mesh>,
+          <mesh
+            key={`rh-${si}-${ri}`}
+            position={[pos[0], RAIL_HIGH, pos[2]]}
+            rotation={[0, side.railRotY, 0]}
+            castShadow
+          >
+            <boxGeometry args={[side.railLength, RAIL_THICKNESS, RAIL_THICKNESS]} />
+            <meshToonMaterial color={RAIL_COLOR} gradientMap={gradientMap} />
+          </mesh>,
+        ]),
+      ])}
+    </>
+  )
+}

--- a/components/world/Hills.tsx
+++ b/components/world/Hills.tsx
@@ -1,0 +1,33 @@
+import * as THREE from 'three'
+
+const gradientMap = (() => {
+  const map = new THREE.DataTexture(new Uint8Array([70, 180]), 2, 1)
+  map.needsUpdate = true
+  return map
+})()
+
+const HILL_COLORS = ['#6a9a5a', '#5e8a4e', '#72a462', '#5a7e4a']
+
+const HILLS = [
+  { position: [0, -1.5, -28] as [number, number, number],   scale: [14, 5, 10] as [number, number, number],  color: 0 },
+  { position: [-20, -2, -24] as [number, number, number],   scale: [11, 4, 8] as [number, number, number],   color: 1 },
+  { position: [20, -1.8, -22] as [number, number, number],  scale: [12, 4.5, 9] as [number, number, number], color: 2 },
+  { position: [-26, -2, -10] as [number, number, number],   scale: [10, 3.5, 8] as [number, number, number], color: 3 },
+  { position: [26, -2, -8] as [number, number, number],     scale: [11, 4, 9] as [number, number, number],   color: 0 },
+  { position: [-24, -2, 10] as [number, number, number],    scale: [10, 3.5, 8] as [number, number, number], color: 1 },
+  { position: [24, -2, 12] as [number, number, number],     scale: [11, 4, 8] as [number, number, number],   color: 2 },
+  { position: [0, -1.8, 26] as [number, number, number],    scale: [13, 4.5, 9] as [number, number, number], color: 3 },
+]
+
+export default function Hills() {
+  return (
+    <>
+      {HILLS.map((hill, i) => (
+        <mesh key={i} position={hill.position} scale={hill.scale} receiveShadow>
+          <sphereGeometry args={[1, 10, 7]} />
+          <meshToonMaterial color={HILL_COLORS[hill.color]} gradientMap={gradientMap} />
+        </mesh>
+      ))}
+    </>
+  )
+}

--- a/components/world/Rocks.tsx
+++ b/components/world/Rocks.tsx
@@ -1,0 +1,48 @@
+import * as THREE from 'three'
+
+function rand(seed: number) {
+  return (((Math.sin(seed * 127.1 + 311.7) * 43758.5453) % 1) + 1) % 1
+}
+
+const gradientMap = (() => {
+  const map = new THREE.DataTexture(new Uint8Array([60, 160]), 2, 1)
+  map.needsUpdate = true
+  return map
+})()
+
+const ROCK_COLORS = ['#8a7e6e', '#7a7060', '#9a8e7e', '#6e6458']
+
+const ROCKS = Array.from({ length: 14 }, (_, i) => {
+  const angle = rand(i * 17 + 1) * Math.PI * 2
+  const radius = 4 + rand(i * 19 + 3) * 6
+  const scale: [number, number, number] = [
+    0.18 + rand(i * 23) * 0.42,
+    0.14 + rand(i * 29) * 0.3,
+    0.16 + rand(i * 31) * 0.38,
+  ]
+  const rotation: [number, number, number] = [
+    rand(i * 37) * Math.PI,
+    rand(i * 41) * Math.PI * 2,
+    rand(i * 43) * Math.PI,
+  ]
+  const color = ROCK_COLORS[i % ROCK_COLORS.length]
+  return {
+    position: [Math.cos(angle) * radius, 0, Math.sin(angle) * radius] as [number, number, number],
+    scale,
+    rotation,
+    color,
+  }
+})
+
+export default function Rocks() {
+  return (
+    <>
+      {ROCKS.map((rock, i) => (
+        <mesh key={i} position={rock.position} scale={rock.scale} rotation={rock.rotation} castShadow receiveShadow>
+          <dodecahedronGeometry args={[1, 0]} />
+          <meshToonMaterial color={rock.color} gradientMap={gradientMap} />
+        </mesh>
+      ))}
+    </>
+  )
+}

--- a/components/world/Trees.tsx
+++ b/components/world/Trees.tsx
@@ -1,0 +1,58 @@
+import { useMemo } from 'react'
+import * as THREE from 'three'
+
+function rand(seed: number) {
+  return (((Math.sin(seed * 127.1 + 311.7) * 43758.5453) % 1) + 1) % 1
+}
+
+const gradientMap = (() => {
+  const map = new THREE.DataTexture(new Uint8Array([80, 200]), 2, 1)
+  map.needsUpdate = true
+  return map
+})()
+
+const CANOPY_COLORS = ['#4a7a35', '#3d6b2a', '#527a3a', '#456e30']
+const TRUNK_COLOR = '#6b4423'
+
+const TREES = Array.from({ length: 22 }, (_, i) => {
+  const angle = (i / 22) * Math.PI * 2 + rand(i * 3) * 0.5
+  const radius = 11 + rand(i * 7) * 9
+  const scale = 0.75 + rand(i * 11) * 0.7
+  const rotY = rand(i * 13) * Math.PI * 2
+  const color = CANOPY_COLORS[i % CANOPY_COLORS.length]
+  return {
+    position: [Math.cos(angle) * radius, 0, Math.sin(angle) * radius] as [number, number, number],
+    scale,
+    rotY,
+    color,
+  }
+})
+
+function Tree({ position, scale, rotY, color }: (typeof TREES)[0]) {
+  return (
+    <group position={position} scale={scale} rotation={[0, rotY, 0]}>
+      <mesh position={[0, 0.4, 0]} castShadow receiveShadow>
+        <cylinderGeometry args={[0.1, 0.15, 0.8, 5]} />
+        <meshToonMaterial color={TRUNK_COLOR} gradientMap={gradientMap} />
+      </mesh>
+      <mesh position={[0, 1.25, 0]} castShadow>
+        <coneGeometry args={[0.65, 1.1, 5]} />
+        <meshToonMaterial color={color} gradientMap={gradientMap} />
+      </mesh>
+      <mesh position={[0, 1.95, 0]} castShadow>
+        <coneGeometry args={[0.45, 0.95, 5]} />
+        <meshToonMaterial color={color} gradientMap={gradientMap} />
+      </mesh>
+    </group>
+  )
+}
+
+export default function Trees() {
+  return (
+    <>
+      {TREES.map((tree, i) => (
+        <Tree key={i} {...tree} />
+      ))}
+    </>
+  )
+}

--- a/components/world/WorldCanvas.tsx
+++ b/components/world/WorldCanvas.tsx
@@ -12,6 +12,11 @@ import ProjectNode from './ProjectNode'
 import SpeechNode from './SpeechNode'
 import SpeechBubble from './SpeechBubble'
 import { WORLD_NODES, SPEECH_NODES, SPEECH_LINES } from './worldConfig'
+import Trees from './Trees'
+import Rocks from './Rocks'
+import Clouds from './Clouds'
+import Fence from './Fence'
+import Hills from './Hills'
 
 useGLTF.preload('/character.glb')
 
@@ -73,7 +78,12 @@ export default function WorldCanvas() {
           shadow-camera-top={15}
           shadow-camera-bottom={-15}
         />
+        <Hills />
         <Floor onFloorClick={handleFloorClick} />
+        <Fence />
+        <Trees />
+        <Rocks />
+        <Clouds />
         <Suspense fallback={null}>
           <Character characterRef={characterRef} walkTarget={walkTarget} />
         </Suspense>


### PR DESCRIPTION
## Summary

- Adds trees, rocks, clouds, a boundary fence, and background hills to the 3D world homepage.
- All geometry is pure Three.js — no additional assets required.
- Timmy is now bounded by the fence (character position clamped to ±9.6 units).

## Detail

- **Trees**: 22 low-poly 5-sided pines at radius 11-20, randomised scale/rotation/colour, fade into fog at the perimeter
- **Rocks**: 14 dodecahedron boulders scattered across the field at varying scales and orientations
- **Clouds**: 6 sphere-cluster clouds at height 10-14, drifting east via useFrame and wrapping at ±32 units
- **Fence**: wooden post-and-rail boundary square at ±10 units with 4-sided posts and two horizontal rails per span
- **Hills**: 8 flattened spheres positioned at the world boundary (~radius 22-28), visible as gentle rises through the fog

## Test plan

- [ ] Trees visible around perimeter, fading into fog at the edges
- [ ] Rocks scattered across the grass
- [ ] Clouds visibly drifting and wrapping
- [ ] Fence posts and rails form a complete boundary square
- [ ] Timmy cannot walk beyond the fence in any direction
- [ ] Hills visible on the horizon
- [ ] npm run build clean