### PR TITLE
fix: fence jitter and speech timeout leak

### DIFF
--- a/components/world/Character.tsx
+++ b/components/world/Character.tsx
@@ -74,6 +74,10 @@ export default function Character({ characterRef, walkTarget }: CharacterProps) 
       char.position.addScaledVector(_direction, WALK_SPEED * delta)
       char.position.x = Math.max(-BOUNDARY, Math.min(BOUNDARY, char.position.x))
       char.position.z = Math.max(-BOUNDARY, Math.min(BOUNDARY, char.position.z))
+      if (walkTarget.current) {
+        walkTarget.current.x = Math.max(-BOUNDARY, Math.min(BOUNDARY, walkTarget.current.x))
+        walkTarget.current.z = Math.max(-BOUNDARY, Math.min(BOUNDARY, walkTarget.current.z))
+      }
     }
 
     // Crossfade animations

--- a/components/world/WorldCanvas.tsx
+++ b/components/world/WorldCanvas.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useRef, useState, useCallback, Suspense } from 'react'
+import { useRef, useState, useCallback, useEffect, Suspense } from 'react'
 import { Canvas } from '@react-three/fiber'
 import { Preload, KeyboardControls, useGLTF } from '@react-three/drei'
 import * as THREE from 'three'
@@ -44,6 +44,10 @@ export default function WorldCanvas() {
   const handleWalkTo = (pos: THREE.Vector3) => {
     walkTarget.current = pos
   }
+
+  useEffect(() => {
+    return () => { if (speechTimeout.current) clearTimeout(speechTimeout.current) }
+  }, [])
 
   const handleSpeechTrigger = useCallback(() => {
     if (speechIndex.current >= speechQueue.current.length) {


### PR DESCRIPTION
## Summary

- Clamps `walkTarget` to `BOUNDARY` after each position clamp in `useFrame`, so `toTarget` can reach < 0.4 and self-clear instead of leaving Timmy stuck juddering against the fence.
- Adds a `useEffect` cleanup in `WorldCanvas` that calls `clearTimeout(speechTimeout.current)` on unmount, preventing a stale `setActiveSpeechLine` call after the user switches to Classic view mid-bubble.

## Test plan

- [ ] Click near or on the fence — Timmy walks to the boundary and stops cleanly
- [ ] Click outside the fence (on visible floor beyond the posts) — same clean stop, no jitter
- [ ] Trigger a speech node then immediately click Classic view — no console warning about state update on unmounted component