### PR TITLE
fix: GLTF cache mutation, hot-path allocations, speech bubble overwrite

### DIFF
--- a/components/world/Character.tsx
+++ b/components/world/Character.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useRef, useEffect } from 'react'
+import { useRef, useEffect, useMemo } from 'react'
 import { useFrame } from '@react-three/fiber'
 import { useGLTF, useAnimations } from '@react-three/drei'
 import * as THREE from 'three'
@@ -19,22 +19,30 @@ interface CharacterProps {
 
 const _direction = new THREE.Vector3()
 const _targetQuat = new THREE.Quaternion()
+const _UP = new THREE.Vector3(0, 1, 0)
+const _toTarget = new THREE.Vector3()
 
 export default function Character({ characterRef, walkTarget }: CharacterProps) {
   const { scene, animations } = useGLTF('/character.glb')
-  const { actions } = useAnimations(animations, characterRef)
+
+  const strippedAnimations = useMemo(() =>
+    animations.map(clip => {
+      const cloned = clip.clone()
+      cloned.tracks = cloned.tracks.filter(
+        track => !(track.name.toLowerCase().includes('hips') && track.name.endsWith('.position'))
+      )
+      return cloned
+    }),
+    [animations]
+  )
+
+  const { actions } = useAnimations(strippedAnimations, characterRef)
   const isWalking = useRef(false)
   const controls = usePlayerControls()
 
   useEffect(() => {
-    // Strip root motion from hips bone so animation doesn't fight our movement code
-    animations.forEach(clip => {
-      clip.tracks = clip.tracks.filter(track =>
-        !(track.name.toLowerCase().includes('hips') && track.name.endsWith('.position'))
-      )
-    })
     if (actions.idle) actions.idle.reset().fadeIn(0.3).play()
-  }, [actions, animations])
+  }, [actions])
 
   useFrame((_, delta) => {
     if (!characterRef.current) return
@@ -42,7 +50,6 @@ export default function Character({ characterRef, walkTarget }: CharacterProps) 
 
     _direction.set(0, 0, 0)
 
-    // WASD: world-space directions so Timmy can walk toward or away from camera
     if (controls.forward) _direction.z -= 1
     if (controls.back) _direction.z += 1
     if (controls.left) _direction.x -= 1
@@ -50,12 +57,11 @@ export default function Character({ characterRef, walkTarget }: CharacterProps) 
 
     const hasKeyInput = _direction.lengthSq() > 0
 
-    // Click-to-walk when no key held
     if (!hasKeyInput && walkTarget.current) {
-      const toTarget = walkTarget.current.clone().sub(char.position)
-      toTarget.y = 0
-      if (toTarget.length() > 0.4) {
-        _direction.copy(toTarget).normalize()
+      _toTarget.copy(walkTarget.current).sub(char.position)
+      _toTarget.y = 0
+      if (_toTarget.length() > 0.4) {
+        _direction.copy(_toTarget).normalize()
       } else {
         walkTarget.current = null
       }
@@ -66,9 +72,8 @@ export default function Character({ characterRef, walkTarget }: CharacterProps) 
     if (moving) {
       _direction.normalize()
 
-      // Timmy's natural forward is +Z, so angle uses atan2(x, z) not atan2(x, -z)
       const angle = Math.atan2(_direction.x, _direction.z)
-      _targetQuat.setFromAxisAngle(new THREE.Vector3(0, 1, 0), angle)
+      _targetQuat.setFromAxisAngle(_UP, angle)
       char.quaternion.slerp(_targetQuat, ROTATION_SPEED * delta)
 
       char.position.addScaledVector(_direction, WALK_SPEED * delta)
@@ -80,7 +85,6 @@ export default function Character({ characterRef, walkTarget }: CharacterProps) 
       }
     }
 
-    // Crossfade animations
     if (moving !== isWalking.current) {
       isWalking.current = moving
       if (moving) {

--- a/components/world/WorldCanvas.tsx
+++ b/components/world/WorldCanvas.tsx
@@ -36,6 +36,7 @@ export default function WorldCanvas() {
   const speechQueue = useRef<string[]>(shuffled)
   const speechIndex = useRef(0)
   const speechTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const isBubbleActive = useRef(false)
 
   const handleFloorClick = (point: THREE.Vector3) => {
     walkTarget.current = new THREE.Vector3(point.x, 0, point.z)
@@ -50,14 +51,18 @@ export default function WorldCanvas() {
   }, [])
 
   const handleSpeechTrigger = useCallback(() => {
+    if (isBubbleActive.current) return
     if (speechIndex.current >= speechQueue.current.length) {
       speechQueue.current = [...SPEECH_LINES].sort(() => Math.random() - 0.5)
       speechIndex.current = 0
     }
     const line = speechQueue.current[speechIndex.current++]
+    isBubbleActive.current = true
     setActiveSpeechLine(line)
-    if (speechTimeout.current) clearTimeout(speechTimeout.current)
-    speechTimeout.current = setTimeout(() => setActiveSpeechLine(null), 4000)
+    speechTimeout.current = setTimeout(() => {
+      setActiveSpeechLine(null)
+      isBubbleActive.current = false
+    }, 4000)
   }, [])
 
   return (


### PR DESCRIPTION
## Summary

Three fixes from the code review:

- **GLTF cache protection**: `clip.tracks` was being mutated in-place on the shared `useGLTF` cache. Now uses `useMemo` to produce cloned, pre-stripped clips before they reach `useAnimations`, leaving the cached model untouched.
- **Hot-path allocations**: two `Vector3` objects were being created inside `useFrame` on every frame — `new THREE.Vector3(0,1,0)` for rotation and `walkTarget.current.clone()` for direction. Both replaced with module-level scratch vectors `_UP` and `_toTarget`, consistent with the existing `_direction` / `_targetQuat` pattern.
- **Speech bubble overwrite**: an `isBubbleActive` ref now prevents a second speech node from firing while a bubble is already on screen. The first line displays for the full 4 seconds before the next one can appear.

## Test plan

- [ ] Idle/walk animations still crossfade correctly
- [ ] Toggle 3D mode off and back on — character loads and animates correctly on remount
- [ ] Walk near two adjacent speech nodes — second does not cut off the first
- [ ] No console errors or warnings during movement
- [ ] npm run build clean